### PR TITLE
Fix name parameter of stats

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ function hacktoberfestStats(username, year, callback) {
             if (!err && res.statusCode == 200) {
               statsInfo.raw = _.extend(statsInfo.raw, data)
               statsInfo.mainStats = {
-                Name: statsInfo.raw.login,
+                Name: statsInfo.raw.name,
                 Completed: statsInfo.raw.total_count > 3 ? true : false,
                 Progress: statsInfo.raw.total_count + '/' + costants.minPullRequests,
                 Contributions: []


### PR DESCRIPTION
Name parameter was previously written as `Name` not `name` and showed results as `undefined`.

P.S. please also update the repository file changes to be the same with npm package file changes. The latest npm package has `Name` parameter, repo's file has `login` parameter which is outdated version.