### PR TITLE
Update Node Versions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [24.x, 22.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The following Node.JS versions:

- 8
- 10
- 12

Have their end of life reached 4, 5, 6 years ago. Hacktoberfests stats should be able to reflect on the reality that there are newer node versions and be able to work with those 