### PR TITLE
Add the new 6 limit for PR's for 2025

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,8 @@ const getMinPullRequests = year => {
   switch (year) {
   case 2018:
     return 5
+  case 2025:
+    return 6
   default:
     return 4
   }


### PR DESCRIPTION
Hacktoberfest Introduced a new change in the amount of Pull Requests required to obtain swag, raising the limit to 6 PR's.

This PR adds an exception to this